### PR TITLE
Make http client in Client struct public

### DIFF
--- a/album_test.go
+++ b/album_test.go
@@ -96,7 +96,7 @@ func TestGetSingleAlbum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &Client{httpClient: tt.args.httpClient, CountryCode: countryCode}
+			client := &Client{HTTPClient: tt.args.httpClient, CountryCode: countryCode}
 
 			album, err := client.GetSingleAlbum(context.Background(), tt.args.ID)
 			if err == nil && tt.wantErr {
@@ -226,7 +226,7 @@ func TestGetAlbumTracks(t *testing.T) {
 
 			c := &Client{
 				CountryCode: countryCode,
-				httpClient:  tt.args.httpClient,
+				HTTPClient:  tt.args.httpClient,
 			}
 
 			tracks, err := c.GetAlbumTracks(context.Background(), tt.args.id)
@@ -281,7 +281,7 @@ func TestGetSingleTrack(t *testing.T) {
 
 			c := &Client{
 				CountryCode: countryCode,
-				httpClient:  tt.args.httpClient,
+				HTTPClient:  tt.args.httpClient,
 			}
 
 			track, err := c.GetSingleTrack(context.Background(), tt.args.id)
@@ -364,7 +364,7 @@ func TestGetTracksByISRC(t *testing.T) {
 
 			c := &Client{
 				CountryCode: countryCode,
-				httpClient:  tt.args.httpClient,
+				HTTPClient:  tt.args.httpClient,
 			}
 
 			tracks, err := c.GetTracksByISRC(context.Background(), tt.args.id, PaginationParams{Limit: 5})
@@ -444,7 +444,7 @@ func TestGetMultipleTracks(t *testing.T) {
 
 			c := &Client{
 				CountryCode: countryCode,
-				httpClient:  tt.args.httpClient,
+				HTTPClient:  tt.args.httpClient,
 			}
 
 			tracks, err := c.GetMultipleTracks(context.Background(), []string{})

--- a/artist_test.go
+++ b/artist_test.go
@@ -47,7 +47,7 @@ func TestGetSingleArtist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &Client{httpClient: tt.args.httpClient}
+			client := &Client{HTTPClient: tt.args.httpClient}
 
 			artist, err := client.GetSingleArtist(context.Background(), tt.args.id)
 			if (err != nil) != tt.wantErr {
@@ -109,7 +109,7 @@ func TestGetAlbumsByArtist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &Client{httpClient: tt.args.httpClient}
+			client := &Client{HTTPClient: tt.args.httpClient}
 
 			albums, err := client.GetAlbumsByArtist(context.Background(), tt.args.id, PaginationParams{Limit: 10})
 			if (err != nil) != tt.wantErr {
@@ -159,7 +159,7 @@ func TestGetMultipleArtists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &Client{httpClient: tt.args.httpClient}
+			client := &Client{HTTPClient: tt.args.httpClient}
 
 			artists, err := client.GetMultipleArtists(context.Background(), tt.args.ids)
 			if (err != nil) != tt.wantErr {
@@ -209,7 +209,7 @@ func TestSimilarArtists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client := &Client{httpClient: tt.args.httpClient}
+			client := &Client{HTTPClient: tt.args.httpClient}
 
 			artists, err := client.GetSimilarArtists(context.Background(), tt.args.id, PaginationParams{Limit: 10})
 			if (err != nil) != tt.wantErr {

--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ type HTTPClient interface {
 
 // Client defines the parameters needed to create a TIDAL API client.
 type Client struct {
-	httpClient  HTTPClient
+	HTTPClient  HTTPClient
 	ContentType string
 	Environment string
 	Token       string
@@ -56,7 +56,7 @@ func NewClient(clientID string, clientSecret string, countryCode string) (*Clien
 	}
 
 	return &Client{
-		httpClient:  httpClient,
+		HTTPClient:  httpClient,
 		ContentType: contentType,
 		Environment: environment,
 		Token:       token,
@@ -130,7 +130,7 @@ func (c *Client) request(ctx context.Context, method string, path string, params
 	req.Header.Set("Authorization", concat("Bearer ", c.Token))
 	req.Header.Set("accept", c.ContentType)
 
-	return processRequest(c.httpClient, req)
+	return processRequest(c.HTTPClient, req)
 }
 
 func toURLParams(input interface{}, countryCode string) string {


### PR DESCRIPTION
I want to be able to configure and set the http client when I want to manually build the `Client` struct instead. Also I might want to configure my http client in a special way, which requires the field to be public.